### PR TITLE
Make matplotlib an optional dependency.

### DIFF
--- a/channelarchiver/plot_channels.py
+++ b/channelarchiver/plot_channels.py
@@ -1,9 +1,12 @@
-
 from channelarchiver import codes, Archiver
-import matplotlib.pyplot as plt
 import re
 
 
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    raise ImportError("The functions in the plotting module require "
+                      "matplotlib to be installed.")
 
 
 def plot(archiver, xchannel, ychannel, start, end):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     packages=['channelarchiver'],
     install_requires=[
         'tzlocal',
-        'matplotlib'
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -2,8 +2,7 @@ import unittest
 import datetime
 from channelarchiver import Archiver, utils
 from tests.mock_archiver import MockArchiver
-from channelarchiver import plot_channels
-
+import nose
 
 
 utc = utils.UTC()
@@ -16,6 +15,11 @@ class TestArchiverPlot(unittest.TestCase):
         self.archiver.archiver = MockArchiver()
 
     def test_plot(self):
+        try:
+            import matplotlib
+        except ImportError:
+            raise nose.SkipTest("This tests featuring requiring matplotlib.")
+        from channelarchiver import plot_channels
         start = datetime.datetime(2012, 1, 1, tzinfo=utc)
         end = datetime.datetime(2013, 1, 1, tzinfo=utc)
         plot_channels.plot(self.archiver,'EXAMPLE:DOUBLE_SCALAR{TD:1}', 'EXAMPLE:INT_WAVEFORM', start, end)


### PR DESCRIPTION
Currently, the setup.py requires matplotlib to be installed. Since matplotlib is only used in the `channelarchiver.plotting` module, I think it should be an optional dependency. This PR:

* removed matplotlib from `install_requires` in setup.py
* configures `SkipTest` for the test covering plotting.py
* raises an informative exception if the user tries to import `channelarchiver.plotting` without matplotlib installed